### PR TITLE
Switch three PI to M_PI to support STRICT_R_HEADERS in Rcpp

### DIFF
--- a/Package/src/pdf_c.cpp
+++ b/Package/src/pdf_c.cpp
@@ -16,7 +16,7 @@ using namespace arma;
 
 double dnormstd(const double& x) {
   double pdf;
-  pdf = exp(-0.5 * x * x) / sqrt(2.0 * PI);
+  pdf = exp(-0.5 * x * x) / sqrt(2.0 * M_PI);
   if (pdf == 0.0) pdf = 0.0 + 2.22507e-24;
   return pdf;
 }
@@ -45,7 +45,7 @@ double depsilon(void) {
 
 double xdt(const double& x, const double& nu) {
   double a, b, pdf;
-  a = Rf_gammafn((nu + 1.0) / 2.0) / sqrt(PI * nu);
+  a = Rf_gammafn((nu + 1.0) / 2.0) / sqrt(M_PI * nu);
   b = Rf_gammafn(nu / 2.0) * pow((1.0 + (x * x) / nu), ((nu + 1.0) / 2.0));
   pdf = a / b;
   return pdf;
@@ -98,7 +98,7 @@ double dsstdstd(const double& x, const double& xi, const double& nu) {
 double dsnormstd(const double& x, const double& xi) {
   double pdf;
   double mu, sigma, z, xxi, g;
-  double m1 = 2.0 / sqrt(2.0 * PI);
+  double m1 = 2.0 / sqrt(2.0 * M_PI);
   double m12 = m1 * m1;
   double xi2 = xi * xi;
   mu = m1 * (xi - 1.0 / xi);


### PR DESCRIPTION
Dear Kevin, Dear MSGARCH team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in three places in one file) PI (instead of the standard C define M_PI) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes PI to M_PI. Your code will then work with and without STRICT_R_HEADERS (as M_PI is an old define from C). PI only works when STRICT_R_HEADERS is not defined.  As RcppArmadillo users you could also use arma::datum::pi but M_PI is indeed pretty common.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).   We do need this fixed this fall though as we plan to upload a changed Rcpp in January.

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.